### PR TITLE
Set the number of threads that OMP can use.

### DIFF
--- a/include/distance_computers.hpp
+++ b/include/distance_computers.hpp
@@ -397,7 +397,7 @@ simsimd_ip_f32_skylake_cycle:
     }
     if constexpr(ALPHA == PDX::L1){
         float res = 0;
-        for (size_t dimension_idx = 0; i < num_dimensions; ++dimension_idx) {
+        for (size_t dimension_idx = 0; dimension_idx < num_dimensions; ++dimension_idx) {
             float tmp = vector1[dimension_idx] - vector2[dimension_idx];
             res += std::fabs(tmp);
         }

--- a/python/pdxearch/index_core.py
+++ b/python/pdxearch/index_core.py
@@ -1,6 +1,9 @@
 import faiss
 import numpy as np
 
+from multiprocessing import cpu_count
+faiss.omp_set_num_threads(cpu_count() // 2)
+
 #
 # Wrapper of FAISS FlatIVF index
 # TODO: Support more distance metrics


### PR DESCRIPTION
Finally found some time to try out the great PDX library!

The initial results were a little too impressive, as I noticed a 200x speedup (instead of the 5-7 reported). Then I realized I was working on a machine with 48 cores - which is still highly impressive to see how PDX uses them all to the max. But FAISS needs a little help to use internal multiprocessing.

The pull request uses the function from the FAISS python bindings to increase the number of threads for OMP, and sets it to half the available cores according to the python multiprocessing library.

(I'd understand if you do not want to do this by default, but would recommend documenting it if so.)